### PR TITLE
Only use tag manager and not gtag.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,6 +62,15 @@
 <body class="antialiased bg-body text-body font-body">
 
   <noscript>You need to enable JavaScript to run this app.</noscript>
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5Z7L39MV" height="0" width="0"
+      style="display:none;visibility:hidden">
+    </iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
   <form name="contact" netlify netlify-honeypot="bot-field" hidden>
     <input type="email" name="email" placeholder="Enter your email" />
     <button type="submit">Subscribe</button>

--- a/public/index.html
+++ b/public/index.html
@@ -13,8 +13,6 @@
     })(window, document, 'script', 'dataLayer', 'GTM-5Z7L39MV');</script>
   <!-- End Google Tag Manager -->
 
-  <!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id=G-14NM591XHP"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-14NM591XHP');</script>
-
   <meta charset="utf-8" />
   <link rel="icon" href="%PUBLIC_URL%/images/nemu-favicon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
We're using double tag managers. This is not advised.

Also, we didn't copy the instructions for google tag manager fully. There's a nice to have noscript snippet.

I need to coordinate with Tom on the deploy of this. So let's not deploy right away.

References
* https://www.youtube.com/watch?v=H5dyrs84bIQ
* https://www.youtube.com/watch?v=PFHY1071B6M&t=17s


<img width="373" alt="image" src="https://github.com/user-attachments/assets/6ac3662b-2819-4ffc-a932-e61b32f8909c">

